### PR TITLE
Missing file extension for release task

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -22,5 +22,5 @@ end
 
 desc 'Release new gem version'
 task :release => :build do
-  system "gem push outpost-#{Outpost::VERSION}"
+  system "gem push outpost-#{Outpost::VERSION}.gem"
 end


### PR DESCRIPTION
Hi vinibaggio,

as far as I can see, a missing file extension in your Rakefile prevents the release task from working:

```
bash-3.2$ rake release
(in /Users/manuel/Dropbox/Projects/outpost)
WARNING:  description and summary are identical
  Successfully built RubyGem
  Name: outpost
  Version: 0.1.0
  File: outpost-0.1.0.gem
Pushing gem to https://rubygems.org...
ERROR:  While executing gem ... (Errno::ENOENT)
    No such file or directory - outpost-0.1.0
```
