### PR TITLE
Store scouts in an Array rather than a Hash

### DIFF
--- a/lib/outpost/application.rb
+++ b/lib/outpost/application.rb
@@ -95,7 +95,7 @@ module Outpost
     def initialize
       @reports     = {}
       @last_status = nil
-      @scouts      = Hash.new { |h, k| h[k] = {} }
+      @scouts      = []
       @notifiers   = {}
       @name        = self.class.name_template
 
@@ -115,8 +115,7 @@ module Outpost
       config.instance_eval(&block)
 
       scout_description.each do |scout, description|
-        @scouts[scout][:description] = description
-        @scouts[scout][:config]      = config
+        @scouts << [ scout, :description => description, :config => config ]
       end
     end
 

--- a/test/outpost/application_test.rb
+++ b/test/outpost/application_test.rb
@@ -38,12 +38,12 @@ describe Outpost::Application do
   end
 
   it "should create correct scout description" do
-    assert_equal(ScoutMock, @scouts.keys.first)
-    assert_equal('master http server', @scouts[ScoutMock][:description])
+    assert_equal(ScoutMock, @scouts.first.first)
+    assert_equal('master http server', @scouts.first.last[:description])
   end
 
   it "should create correct scout config" do
-    config = @scouts[ScoutMock][:config]
+    config = @scouts.first.last[:config]
     assert_equal({:host => 'localhost'}, config.options)
     assert_equal({{:response_code => 200} => :up}, config.reports)
   end


### PR DESCRIPTION
I am using Outpost to set up server monitoring, and wanted to use more than one of a type of Scout in the Application. However, the @scouts were stored in an Array instead of a Hash in Application instances. This patch stores them in an Array so that you can have multiples of one type of Scout.
