### PR TITLE
Graceful fail on no response time

### DIFF
--- a/lib/outpost/application.rb
+++ b/lib/outpost/application.rb
@@ -95,7 +95,7 @@ module Outpost
     def initialize
       @reports     = {}
       @last_status = nil
-      @scouts      = Hash.new { |h, k| h[k] = {} }
+      @scouts      = []
       @notifiers   = {}
       @name        = self.class.name_template
 
@@ -115,8 +115,7 @@ module Outpost
       config.instance_eval(&block)
 
       scout_description.each do |scout, description|
-        @scouts[scout][:description] = description
-        @scouts[scout][:config]      = config
+        @scouts << [ scout, :description => description, :config => config ]
       end
     end
 

--- a/lib/outpost/expectations/response_time.rb
+++ b/lib/outpost/expectations/response_time.rb
@@ -20,6 +20,8 @@ module Outpost
 
       # Method that will be used as an expectation to evaluate response time
       def evaluate_response_time(scout, rules)
+        return false if !scout.response_time
+
         rules.all? do |rule, comparison|
           scout.response_time.send(RESPONSE_TIME_MAPPING[rule], comparison)
         end

--- a/test/outpost/application_test.rb
+++ b/test/outpost/application_test.rb
@@ -38,12 +38,12 @@ describe Outpost::Application do
   end
 
   it "should create correct scout description" do
-    assert_equal(ScoutMock, @scouts.keys.first)
-    assert_equal('master http server', @scouts[ScoutMock][:description])
+    assert_equal(ScoutMock, @scouts.first.first)
+    assert_equal('master http server', @scouts.first.last[:description])
   end
 
   it "should create correct scout config" do
-    config = @scouts[ScoutMock][:config]
+    config = @scouts.first.last[:config]
     assert_equal({:host => 'localhost'}, config.options)
     assert_equal({{:response_code => 200} => :up}, config.reports)
   end

--- a/test/outpost/expectations/response_time_test.rb
+++ b/test/outpost/expectations/response_time_test.rb
@@ -60,6 +60,10 @@ describe Outpost::Expectations::ResponseTime do
       SubjectTime.evaluation_method
   end
 
+  it 'should fail correctly when response_time is nil' do
+    refute SubjectTime.evaluate_response_time(OpenStruct.new(:response_time => nil), { :less_than => 1 })
+  end
+
   private
   def scout_stub
     build_stub(:response_time => 300)


### PR DESCRIPTION
If the Net libraries fail, a response time may not be available. This ensures that the Scout doesn't die if this is the case.
