### PR TITLE
Add tcp scout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .yardoc
+.rvmrc
+*.gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,6 @@ GEM
   specs:
     activesupport (3.0.3)
     addressable (2.2.2)
-    archive-tar-minitar (0.5.2)
     columnize (0.3.2)
     daemons (1.1.0)
     eventmachine (0.12.10)
@@ -13,8 +12,6 @@ GEM
       rack (>= 1.1.0, < 2)
     i18n (0.5.0)
     linecache (0.43)
-    linecache19 (0.5.11)
-      ruby_core_source (>= 0.1.4)
     mail (2.2.15)
       activesupport (>= 2.3.6)
       i18n (>= 0.4.0)
@@ -33,16 +30,6 @@ GEM
       ruby-debug-base (~> 0.10.4.0)
     ruby-debug-base (0.10.4)
       linecache (>= 0.3)
-    ruby-debug-base19 (0.11.24)
-      columnize (>= 0.3.1)
-      linecache19 (>= 0.5.11)
-      ruby_core_source (>= 0.1.4)
-    ruby-debug19 (0.11.6)
-      columnize (>= 0.3.1)
-      linecache19 (>= 0.5.11)
-      ruby-debug-base19 (>= 0.11.19)
-    ruby_core_source (0.1.4)
-      archive-tar-minitar (>= 0.5.2)
     sinatra (1.1.2)
       rack (~> 1.1)
       tilt (~> 1.2)
@@ -74,7 +61,6 @@ DEPENDENCIES
   rack
   rake
   ruby-debug
-  ruby-debug19
   sinatra
   thin
   tinder

--- a/lib/outpost/scouts.rb
+++ b/lib/outpost/scouts.rb
@@ -1,2 +1,3 @@
 require 'outpost/scouts/http'
 require 'outpost/scouts/ping'
+require 'outpost/scouts/tcp'

--- a/lib/outpost/scouts/ping.rb
+++ b/lib/outpost/scouts/ping.rb
@@ -1,9 +1,4 @@
-begin
-  require 'net/ping/external'
-rescue LoadError => e
-  puts "Please install net-ping gem: gem install net-ping".
-  raise
-end
+require 'net/ping/external'
 
 require 'outpost/expectations'
 

--- a/lib/outpost/scouts/tcp.rb
+++ b/lib/outpost/scouts/tcp.rb
@@ -1,14 +1,13 @@
-require 'net/ping/external'
+require 'net/ping/tcp'
 require 'outpost/expectations'
 
 module Outpost
   module Scouts
-    # Uses system's "ping" command line tool to check if the server is
-    # responding in a timely manner.
+    # Uses net/ping tcp pinger to check if port is open
     #
     # * Responds to response_time expectation
     #   ({Outpost::Expectations::ResponseTime})
-    class Ping < Outpost::Scout
+    class Tcp < Ping
       extend Outpost::Expectations::ResponseTime
       attr_reader :response_time
       report_data :response_time
@@ -17,15 +16,18 @@ module Outpost
       # @param [Hash] Options to setup the scout
       # @option options [String] :host The host that will be "pinged".
       # @option options [Object] :pinger An object that can ping hosts.
-      #   Defaults to Net::Ping::External.new
+      #   Defaults to Net::Ping::Tcp.new
       def setup(options)
-        @host   = options[:host]
-        @pinger = options[:pinger] || Net::Ping::External.new
+        host   = options[:host]
+        port   = options[:port]
+        pinger = options[:pinger] || Net::Ping::TCP
+
+        @pinger = pinger.new(host, port)
       end
 
       # Runs the scout, pinging the host and getting the duration.
       def execute
-        if @pinger.ping(@host)
+        if @pinger.ping?
           # Miliseconds
           @response_time = @pinger.duration * 1000
         end

--- a/lib/outpost/scouts/tcp.rb
+++ b/lib/outpost/scouts/tcp.rb
@@ -20,9 +20,10 @@ module Outpost
       def setup(options)
         host   = options[:host]
         port   = options[:port]
+        timeout= options[:timeout] || 3
         pinger = options[:pinger] || Net::Ping::TCP
 
-        @pinger = pinger.new(host, port)
+        @pinger = pinger.new(host, port, timeout)
       end
 
       # Runs the scout, pinging the host and getting the duration.

--- a/outpost.gemspec
+++ b/outpost.gemspec
@@ -16,4 +16,6 @@ Gem::Specification.new do |s|
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
+
+  s.add_dependency "net-ping"
 end

--- a/test/outpost/scouts/tcp_test.rb
+++ b/test/outpost/scouts/tcp_test.rb
@@ -10,7 +10,7 @@ describe Outpost::Scouts::Tcp do
     subject = Outpost::Scouts::Tcp.new "test", config
     subject.execute
 
-    assert subject.response_time < 1
+    assert subject.response_time < 100
   end
 
   it "should set the time to nil when it fails" do

--- a/test/outpost/scouts/tcp_test.rb
+++ b/test/outpost/scouts/tcp_test.rb
@@ -1,0 +1,32 @@
+require 'test_helper'
+
+describe Outpost::Scouts::Tcp do
+  it "should set the time of ping in milliseconds" do
+    @server = Server.new
+    @server.boot(TestApp)
+    @server.wait_until_booted
+
+    config = config_stub(:port => 9595)
+    subject = Outpost::Scouts::Tcp.new "test", config
+    subject.execute
+
+    assert subject.response_time < 1
+  end
+
+  it "should set the time to nil when it fails" do
+    #nothing uses this port by deafult
+    config = config_stub(:port => 16)
+    subject = Outpost::Scouts::Tcp.new "test", config
+    subject.execute
+
+    assert subject.response_time.nil?
+  end
+
+  private
+
+  def config_stub(options={})
+    options = {:host => 'localhost'}.merge options
+
+    build_stub(:options => options)
+  end  
+end


### PR DESCRIPTION
Added tcp scout for checking if port is open. It may need some enhancements, but looks like it works. 

Also, i`ve added net/ping to gem dependencies, as 'require 'outpost'' fails without it. 
